### PR TITLE
fix res.redirect method to match express api

### DIFF
--- a/lib/response.js
+++ b/lib/response.js
@@ -92,13 +92,17 @@ Response.prototype.json = function(obj) {
   if (!this.getHeader('Content-Type')) {
     this.setHeader('Content-Type', 'application/json');
   }
-  
+
   var body = JSON.stringify(obj);
   return this.send(body);
 }
 
-Response.prototype.redirect = function(url, status) {
-  this.statusCode = status || 302;
+Response.prototype.redirect = function(status, url) {
+  if (typeof status === 'string') {
+    url = status;
+    status = 302;
+  }
+  this.statusCode = status;
   this.setHeader('Location', url);
   this.end();
 };


### PR DESCRIPTION
The current api is `res.redirect([status], url)` as explained in the documentation:

https://expressjs.com/en/3x/api.html#res.redirect
https://expressjs.com/en/api.html#res.redirect

I think `res.redirect(url, status)` was deprecated in 2.x but I can't find more info.